### PR TITLE
Configure setuid and setgid with environment variables

### DIFF
--- a/stunnel.conf.template
+++ b/stunnel.conf.template
@@ -1,8 +1,8 @@
 cert = ${STUNNEL_CRT}
 key = ${STUNNEL_KEY}
 
-setuid = stunnel
-setgid = stunnel
+setuid = ${STUNNEL_UID}
+setgid = ${STUNNEL_GID}
 
 pid = /var/run/stunnel/stunnel.pid
 

--- a/stunnel.sh
+++ b/stunnel.sh
@@ -2,6 +2,8 @@
 
 export STUNNEL_CONF="/etc/stunnel/stunnel.conf"
 export STUNNEL_DEBUG="${STUNNEL_DEBUG:-7}"
+export STUNNEL_UID="${STUNNEL_UID:-stunnel}"
+export STUNNEL_GID="${STUNNEL_GID:-stunnel}"
 export STUNNEL_CLIENT="${STUNNEL_CLIENT:-no}"
 #export STUNNEL_SNI="${STUNNEL_SNI:-}"
 export STUNNEL_CAFILE="${STUNNEL_CAFILE:-/etc/ssl/certs/ca-certificates.crt}"


### PR DESCRIPTION
This change allows to set custom values for setuid and setgid, this is necessary in some cases where the default `stunnel` user does not have certain permissions.